### PR TITLE
Improve the performSegue overriding

### DIFF
--- a/Source/UIViewController+SegueContext.m
+++ b/Source/UIViewController+SegueContext.m
@@ -12,6 +12,8 @@
 
 @implementation UIViewController (SegueContext)
 
+#ifdef DISABLE_SWIZZLING
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
@@ -21,5 +23,7 @@
 }
 
 #pragma clang diagnostic pop
+
+#endif
 
 @end


### PR DESCRIPTION
We do not need to call the `super.prepareForSegue` any more.

Inspired from this Issue https://github.com/tokorom/SegueContext/issues/1
