### PR TITLE
Prevent submission error

### DIFF
--- a/SegueContext.xcodeproj/project.pbxproj
+++ b/SegueContext.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 		F30BD6741BBF72DA00F8CF6C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -408,7 +408,7 @@
 		F30BD6751BBF72DA00F8CF6C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -610,6 +610,7 @@
 				F39939C91D83F7D6001FA167 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
I am facing an issue when I am trying to upload binary to iTC that showing error messages as follows:

> ERROR ITMS-90171: "Invalid Bundle Structure - The binary file 'XXX.app/Frameworks/SegueContext.framework/libswiftRemoteMirror.dylib' is not permitted. Your app can’t contain standalone executables or libraries, other than the CFBundleExecutable of supported bundles. Refer to the Bundle Programming Guide at https://developer.apple.com/go/?id=bundle-structure for information on the iOS app bundle structure."
ERROR ITMS-90171: "Invalid Bundle Structure - The binary file 'XXX.app/Frameworks/SegueContext.framework/libswiftRemoteMirror.dylib' is not permitted. Your app can’t contain standalone executables or libraries, other than the CFBundleExecutable of supported bundles. Refer to the Bundle Programming Guide at https://developer.apple.com/go/?id=bundle-structure for information on the iOS app bundle structure."

> ERROR ITMS-90206: "Invalid Bundle. The bundle at 'XXX.app/Frameworks/SegueContext.framework' contains disallowed file 'Frameworks'."
ERROR ITMS-90206: "Invalid Bundle. The bundle at 'XXX.app/Frameworks/SegueContext.framework' contains disallowed file 'Frameworks'."

This PR prevents these errors, but I am not sure that this is our project specific problem or there are other people facing this problem.

Environment

- Xcode 8.3.1
- Carthage 0.20.1
- SegueContext 3.0.0

I have been used this workaround since older version of SegueContext but haven't send PR.